### PR TITLE
Modification of the main processing loop in metrics poller

### DIFF
--- a/src/main/java/com/boundary/metrics/vmware/poller/VMwareClient.java
+++ b/src/main/java/com/boundary/metrics/vmware/poller/VMwareClient.java
@@ -212,7 +212,7 @@ public class VMwareClient implements Connection {
                 // Display summary information about the product name, server type, and product version
                 AboutInfo about = serviceContent.getAbout();
                 LOG.info("Successfully connected to {} ({}) using API version {} (of type {})",
-                        getHost(), about.getFullName(), about.getApiVersion(), about.getApiType());
+                        getName(), about.getFullName(), about.getApiVersion(), about.getApiType());
             } catch (Exception e) {
                 LOG.error("Unable to connect to " + getHost(), e);
             }


### PR DESCRIPTION
1. Removed redundant checking of connection which is handle in the VMWareClient.connect() method
2. Disconnect the client connection if an error occurrs during polling for metrics so that a new connection is established
