### PR TITLE
Removed unnecessary call to disconnect() 

### DIFF
--- a/src/main/java/com/boundary/metrics/vmware/poller/VMwarePerfPoller.java
+++ b/src/main/java/com/boundary/metrics/vmware/poller/VMwarePerfPoller.java
@@ -202,9 +202,7 @@ public class VMwarePerfPoller implements Runnable, MetricSet {
             } catch (Throwable e) {
                 LOG.error("Encountered unexpected error while polling for performance data", e);
             } finally {
-            	// Disconnect our client so that we try to reconnect
-            	// after an error
-            	client.disconnect();
+            	// Release the lock and stop our timer
                 lock.set(false);
                 timer.stop();
             }


### PR DESCRIPTION
Removed unnecessary call to disconnect() on the VMWareClient instance during the finally clause in the metrics polling loop
