### PR TITLE
Truncating the number of metrics sent to Boundary

### DIFF
--- a/src/main/java/com/boundary/metrics/vmware/client/metrics/MetricClient.java
+++ b/src/main/java/com/boundary/metrics/vmware/client/metrics/MetricClient.java
@@ -127,6 +127,11 @@ public class MetricClient {
      * @param measurements Metrics measurements
      */
     public void addMeasurements(List<Measurement> measurements) {
+    	if (LOG.isDebugEnabled()) {
+    		for (Measurement m : measurements) {
+    			LOG.debug(m.toString());
+    		}
+    	}
         sendMeasurements(FluentIterable.from(measurements)
                 .transform(MetricUtils.toBulkEntry())
                 .toList());
@@ -147,6 +152,7 @@ public class MetricClient {
                             ClientResponse response = f.get();
                             String entity = response.getEntity(String.class);
                             response.close();
+                            LOG.debug("HTTPS Result: {}",response.getStatus());
                             if (Response.Status.OK.getStatusCode() != response.getStatus()) {
                                 LOG.error("Unexpected response adding measurements: {} - {}", response.getStatusInfo(), entity);
                                 throw new RuntimeException(entity);

--- a/src/main/java/com/boundary/metrics/vmware/poller/VMWareMetricCollector.java
+++ b/src/main/java/com/boundary/metrics/vmware/poller/VMWareMetricCollector.java
@@ -134,6 +134,7 @@ public class VMWareMetricCollector implements Runnable, MetricSet {
 				int obsDomainId = meterClient.createOrGetMeterMetadata(meterName).getObservationDomainId();
 				
 				List<Measurement> measurements = vmwClient.getMeasurements(mor,entityName,obsDomainId,20,lastPoll,now,job.getMetadata());
+				LOG.debug("{} measurements for managed object {}",measurements.size(), entityName);
 
 				// Send metrics
 				if (!measurements.isEmpty()) {


### PR DESCRIPTION
- Fix issue by which only the last retrieve metric was being pushed to Boundary.
- Additional logging to help diagnose number of metrics sent to Boundary