### PR TITLE
Incorrectly using uppercase for unit and defaultAggregate metric definitions

### DIFF
--- a/src/main/java/com/boundary/metrics/vmware/client/metrics/MeasurementBuilder.java
+++ b/src/main/java/com/boundary/metrics/vmware/client/metrics/MeasurementBuilder.java
@@ -24,8 +24,7 @@ public class MeasurementBuilder {
 	/**
 	 * Constructor
 	 */
-    MeasurementBuilder() { 
-    	
+    public MeasurementBuilder() { 
     }
 
     private int sourceId;

--- a/src/main/java/com/boundary/metrics/vmware/poller/MetricAggregates.java
+++ b/src/main/java/com/boundary/metrics/vmware/poller/MetricAggregates.java
@@ -1,5 +1,5 @@
 package com.boundary.metrics.vmware.poller;
 
 public enum MetricAggregates {
-	AVG, MAX, MIN, SUM;
+	avg, max, min, sum;
 }

--- a/src/main/java/com/boundary/metrics/vmware/poller/MetricUnit.java
+++ b/src/main/java/com/boundary/metrics/vmware/poller/MetricUnit.java
@@ -1,5 +1,5 @@
 package com.boundary.metrics.vmware.poller;
 
 public enum MetricUnit {
-	BYTECOUNT, DURATION, NUMBER, PERCENT;
+	bytecount, duration, number, percent;
 }

--- a/src/test/java/com/boundary/metrics/vmware/client/MetricClientTest.java
+++ b/src/test/java/com/boundary/metrics/vmware/client/MetricClientTest.java
@@ -23,14 +23,18 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
+import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.boundary.metrics.vmware.client.metrics.Measurement;
+import com.boundary.metrics.vmware.client.metrics.MeasurementBuilder;
 import com.boundary.metrics.vmware.client.metrics.MetricClient;
 import com.boundary.metrics.vmware.poller.MetricDefinition;
 import com.boundary.metrics.vmware.poller.MetricDefinitionBuilder;
@@ -116,5 +120,23 @@ public class MetricClientTest {
 		metrics.add(builder.build());
 		
 		metricClient.createUpdateMetrics(metrics);
+	}
+	
+	@Test
+	public void testSendMeasurement() throws InterruptedException {
+		List<Measurement> measurements = new ArrayList<Measurement>();
+		MeasurementBuilder builder = new MeasurementBuilder();
+		
+		
+		for (int i = 10 ; i > 0 ; i--) {
+			measurements.clear();
+			builder.setMetric("SYSTEM_CPU_USAGE_AVERAGE")
+		       .setSourceId(100)
+		       .setMeasurement(0.53)
+		       .setTimestamp(new DateTime());
+			measurements.add(builder.build());
+			metricClient.addMeasurements(measurements);
+			Thread.sleep(1000);
+		}
 	}
 }

--- a/src/test/java/com/boundary/metrics/vmware/client/MetricClientTest.java
+++ b/src/test/java/com/boundary/metrics/vmware/client/MetricClientTest.java
@@ -14,8 +14,8 @@
 
 package com.boundary.metrics.vmware.client;
 
-import static com.boundary.metrics.vmware.poller.MetricAggregates.AVG;
-import static com.boundary.metrics.vmware.poller.MetricUnit.NUMBER;
+import static com.boundary.metrics.vmware.poller.MetricAggregates.avg;
+import static com.boundary.metrics.vmware.poller.MetricUnit.number;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assume.assumeTrue;
 
@@ -83,9 +83,9 @@ public class MetricClientTest {
 		       .setDisplayName("System Foo")
 		       .setDisplayNameShort("Foo")
 		       .setDescription("Foo")
-		       .setUnit(NUMBER)
+		       .setUnit(number)
 		       .setDefaultResolutionMS(20000)
-		       .setDefaultAggregate(AVG);
+		       .setDefaultAggregate(avg);
 		MetricDefinition definition = builder.build();
 		metricClient.createUpdateMetric(definition);
 	}
@@ -98,25 +98,25 @@ public class MetricClientTest {
 		       .setDisplayName("JDG One")
 		       .setDisplayNameShort("JDG 1")
 		       .setDescription("JDG one metric")
-		       .setUnit(NUMBER)
+		       .setUnit(number)
 		       .setDefaultResolutionMS(20000)
-		       .setDefaultAggregate(AVG);
+		       .setDefaultAggregate(avg);
 		metrics.add(builder.build());
 		builder.setMetric("JDG_TWO")
 	       .setDisplayName("JDG Two")
 	       .setDisplayNameShort("JDG 2")
 	       .setDescription("JDG two metric")
-	       .setUnit(NUMBER)
+	       .setUnit(number)
 	       .setDefaultResolutionMS(20000)
-	       .setDefaultAggregate(AVG);
+	       .setDefaultAggregate(avg);
 		metrics.add(builder.build());
 		builder.setMetric("JDG_THREE")
 	       .setDisplayName("JDG Three")
 	       .setDisplayNameShort("JDG 3")
 	       .setDescription("JDG three metric")
-	       .setUnit(NUMBER)
+	       .setUnit(number)
 	       .setDefaultResolutionMS(20000)
-	       .setDefaultAggregate(AVG);
+	       .setDefaultAggregate(avg);
 		metrics.add(builder.build());
 		
 		metricClient.createUpdateMetrics(metrics);
@@ -133,7 +133,7 @@ public class MetricClientTest {
 			builder.setMetric("SYSTEM_CPU_USAGE_AVERAGE")
 		       .setSourceId(100)
 		       .setMeasurement(0.53)
-		       .setTimestamp(new DateTime());
+		       .setTimestamp(DateTime.now());
 			measurements.add(builder.build());
 			metricClient.addMeasurements(measurements);
 			Thread.sleep(1000);

--- a/src/test/java/com/boundary/metrics/vmware/poller/MORCatalogFactoryTest.java
+++ b/src/test/java/com/boundary/metrics/vmware/poller/MORCatalogFactoryTest.java
@@ -70,6 +70,18 @@ public class MORCatalogFactoryTest {
 		MORCatalog inventory = MORCatalogFactory.create(TEST_CATALOG_FILE);
 		
 		assertEquals("check definitions",7,inventory.getDefinitions().size());
+		
+		List<MetricDefinition> definitions = inventory.getDefinitions();
+		
+		for (MetricDefinition definition : definitions) {
+			
+			switch(definition.getMetric()) {
+			case "SYSTEM_CPU_USAGE_AVERAGE":
+				assertEquals("Check unit",MetricUnit.percent,definition.getUnit());
+				break;
+			}
+			
+		}
 	}
 	
 	@Test
@@ -84,13 +96,13 @@ public class MORCatalogFactoryTest {
 		assertEquals("check VirtualMachine definition for cpu.usage.AVERAGE","SYSTEM_CPU_USAGE_AVERAGE",virtualMachine.get("cpu.usage.AVERAGE").getMetric());
 		assertNotNull("check VirtualMachine for cpu.usage.MINIMUM",virtualMachine.get("cpu.usage.MINIMUM"));
 		assertEquals("check VirtualMachine definition for cpu.usage.MINIMUM","SYSTEM_CPU_USAGE_MINIMUM",virtualMachine.get("cpu.usage.MINIMUM").getMetric());
-		assertNotNull("check VirtualMachine for cpu.idle.SUMMATION",virtualMachine.get("cpu.idle.SUMMATION"));
-		assertEquals("check VirtualMachine definition for cpu.idle.SUMMATION","SYSTEM_CPU_IDLE_TOTAL",virtualMachine.get("cpu.idle.SUMMATION").getMetric());
+		assertNotNull("check VirtualMachine for cpu.usage.MAXIMUM",virtualMachine.get("cpu.usage.MAXIMUM"));
+		assertEquals("check VirtualMachine definition for cpu.usage.MAXIMUM","SYSTEM_CPU_USAGE_MAXIMUM",virtualMachine.get("cpu.usage.MAXIMUM").getMetric());
 
 		Map<String, MetricDefinition> hostSystem = metrics.get("HostSystem");
 		assertNotNull("check HostSystem for cpu.usage.AVERAGE",hostSystem.get("cpu.usage.AVERAGE"));
 		assertNotNull("check HostSystem for cpu.usage.MINIMUM",hostSystem.get("cpu.usage.MINIMUM"));
-		assertNotNull("check HostSystem for cpu.usage.IDLE",hostSystem.get("cpu.usage.IDLE"));
+		assertNotNull("check HostSystem for cpu.usage.MAXIMUM",hostSystem.get("cpu.usage.MAXIMUM"));
 
 		Map<String, MetricDefinition> datastore = metrics.get("Datastore");
 		assertNotNull("check Datastore for disk.capacity.SUM",datastore.get("disk.capacity.SUM"));

--- a/src/test/resources/test-catalog.json
+++ b/src/test/resources/test-catalog.json
@@ -2,69 +2,69 @@
 	"definitions": 
 	[
 		{
-			"defaultAggregate": "AVG",
+			"defaultAggregate": "avg",
 			"defaultResolutionMS": 0,
 			"description": "CPU Average Utilization",
 			"displayName": "CPU Average Utilization",
 			"displayNameShort": "CPU Avg Util",
 			"metric": "SYSTEM_CPU_USAGE_AVERAGE",
-			"unit": "NUMBER"
+			"unit": "percent"
 		},
 
 		{
-			"defaultAggregate": "SUM",
+			"defaultAggregate": "min",
 			"defaultResolutionMS": 0,
 			"description": "CPU Minimum Utilization",
 			"displayName": "CPU Minimum Utilization",
 			"displayNameShort": "CPU Min Util",
 			"metric": "SYSTEM_CPU_USAGE_MINIMUM",
-			"unit": "NUMBER"
+			"unit": "percent"
 		},
 
 		{
-			"defaultAggregate": "SUM",
+			"defaultAggregate": "max",
 			"defaultResolutionMS": 0,
-			"description": "CPU Idle Total",
-			"displayName": "CPU Idle Total",
-			"displayNameShort": "CPU Idle Total",
-			"metric": "SYSTEM_CPU_IDLE_TOTAL",
-			"unit": "NUMBER"
+			"description": "CPU Maximum Utilization",
+			"displayName": "CPU Maximum Utilization",
+			"displayNameShort": "CPU Max Util",
+			"metric": "SYSTEM_CPU_USAGE_MAXIMUM",
+			"unit": "percent"
 		},
 		{
-			"defaultAggregate": "SUM",
+			"defaultAggregate": "sum",
 			"defaultResolutionMS": 0,
 			"description": "CPU Useage Idle",
 			"displayName": "CPU Useage Idle",
 			"displayNameShort": "CPU Use I",
 			"metric": "SYSTEM_CPU_USAGE_IDLE",
-			"unit": "NUMBER"
+			"unit": "number"
 		},
 		{
-			"defaultAggregate": "SUM",
+			"defaultAggregate": "sum",
 			"defaultResolutionMS": 0,
 			"description": "Disk Capacity Total",
 			"displayName": "Disk Capacity Total",
 			"displayNameShort": "Disk Cap Tot",
 			"metric": "SYSTEM_DISK_CAPACITY_SUM",
-			"unit": "NUMBER"
+			"unit": "number"
 		},
 		{
-			"defaultAggregate": "SUM",
+			"defaultAggregate": "sum",
 			"defaultResolutionMS": 0,
 			"description": "Disk Provisioned Total",
 			"displayName": "Disk Provisioned Total",
 			"displayNameShort": "Disk Prov Tot",
 			"metric": "SYSTEM_DISK_PROVISIONED_SUM",
-			"unit": "NUMBER"
+			"unit": "number"
 		},
 		{
-			"defaultAggregate": "SUM",
+			"defaultAggregate": "sum",
 			"defaultResolutionMS": 0,
 			"description": "Disk Used Total",
 			"displayName": "Disk Used Total",
 			"displayNameShort": "Disk Used Tot",
 			"metric": "SYSTEM_DISK_USED_SUM",
-			"unit": "NUMBER"
+			"unit": "number"
 		}
 	],
 
@@ -83,10 +83,9 @@
 					"name": "cpu.usage.MINIMUM",
 					"metric": "SYSTEM_CPU_USAGE_MINIMUM"
 				},
-
 				{
-					"name": "cpu.idle.SUMMATION",
-					"metric": "SYSTEM_CPU_IDLE_TOTAL"
+					"name": "cpu.usage.MAXIMUM",
+					"metric": "SYSTEM_CPU_USAGE_MAXIMUM"
 				}
 			]
 		},
@@ -104,10 +103,9 @@
 					"name": "cpu.usage.MINIMUM",
 					"metric": "SYSTEM_CPU_USAGE_MINIMUM"
 				},
-
 				{
-					"name": "cpu.usage.IDLE",
-					"metric": "SYSTEM_CPU_USAGE_IDLE"
+					"name": "cpu.usage.MAXIMUM",
+					"metric": "SYSTEM_CPU_USAGE_MAXIMUM"
 				}
 			]
 		},


### PR DESCRIPTION
- Changed MetricUnit enum to lowercase
- Change DefaultAggregate enum to lowercase
- Added additional tests that send measurements